### PR TITLE
fix: resolve incompatible method declaration in plugin file

### DIFF
--- a/Yuoshi.php
+++ b/Yuoshi.php
@@ -159,7 +159,7 @@ class Yuoshi extends StudIPPlugin implements StandardPlugin, SystemPlugin, JsonA
     /**
      * @inheritDoc
      */
-    public function registerSchemas()
+    public function registerSchemas(): array
     {
         return [
             \Xyng\Yuoshi\Model\UserPackageProgress::class => \Xyng\Yuoshi\Api\Schema\UserPackageProgress::class,


### PR DESCRIPTION
Das sollte den Fehler mit den StudIP-Trunk beheben.
Kann natürlich sein, dass es danach noch einen weiteren gibt.
Ich habe hier gerade nichts zum testen da...