### PR TITLE
feature: authority helper order

### DIFF
--- a/src/Helper/AuthorityHelper.php
+++ b/src/Helper/AuthorityHelper.php
@@ -45,6 +45,7 @@ class AuthorityHelper {
                 ]
             ] + ($conditions['joins'] ?? []),
             'conditions' => $queryCond + ($conditions['conditions'] ?? []),
+            'order' => $conditions['order'] ?? [],
         ];
     }
 }

--- a/src/Helper/DBHelper.php
+++ b/src/Helper/DBHelper.php
@@ -174,6 +174,13 @@ class DBHelper {
         }
 
         $orders = $query['order'] ?? [];
+
+        // fallback when string is given instead of array
+        if ($orders && is_string($orders)) {
+            $orders = trim($orders);
+            $orders = $orders ? [$orders] : false;
+        }
+
         if ($orders) {
             $sql .= "\nORDER BY\n" . join(",\n", $orders);
         }


### PR DESCRIPTION
This allows passing the order option to the authority helper.
Furthermore, it is now also possible to pass a string instead of an array, when only a single order expression is required.